### PR TITLE
Reduce number of data fetches

### DIFF
--- a/src/components/search/-SearchResults.vue
+++ b/src/components/search/-SearchResults.vue
@@ -45,6 +45,8 @@ export default {
   },
   methods: {
     getData() {
+      // Using firebase.firestore.collection().get() might be doing more work than needed. See:
+      // https://firebase.google.com/docs/database/web/read-and-write#read_data_once_with_get
       collection.get().then(colection => {
         this.wordsList = colection.docs.map(doc => doc.data())
       })


### PR DESCRIPTION
This info might help with the problem of too many fetches when searching:
"Unnecessary use of get() can increase use of bandwidth and lead to loss of performance, which can be prevented by using a realtime listener"
Taken from https://firebase.google.com/docs/database/web/read-and-write#read_data_once_with_get